### PR TITLE
feat: Implement social login with Google and Facebook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# MongoDB Connection String
+MONGO_URI=your_mongodb_connection_string
+
+# JWT Configuration
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRE=30d
+JWT_COOKIE_EXPIRE=30
+
+# Server Port
+PORT=5000
+
+# Frontend URL (for OAuth redirects)
+CLIENT_URL=http://localhost:3000
+
+# Google OAuth Credentials
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+
+# Facebook OAuth Credentials
+FACEBOOK_APP_ID=your_facebook_app_id
+FACEBOOK_APP_SECRET=your_facebook_app_secret

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a web-based apartment rental platform connecting apartment owner
 
 ### User Roles & Authentication
 - **Owners and Agents:** Must complete manual KYC verification before managing apartments.
-- **Renters:** Can register/login using email/password, Google, or Facebook.
+- **Renters:** Can register and log in using a traditional email/password combination or via social providers like Google and Facebook.
 - Role-based access control for Owners, Agents, Renters, and Admin.
 
 ### Apartment Listings
@@ -57,11 +57,16 @@ This project is a web-based apartment rental platform connecting apartment owner
 1. Clone the repository.
 2. Install backend dependencies: `npm install`
 3. Navigate to the client directory and install frontend dependencies: `cd client && npm install`
-4. Create a `.env` file in the root directory and add the following environment variables:
+4. Create a `.env` file in the root directory by copying the example: `cp .env.example .env`. Then, add your values for the following variables:
    - `MONGO_URI`: Your MongoDB connection string
    - `JWT_SECRET`: A secret for signing JWTs
    - `JWT_EXPIRE`: JWT expiration time (e.g., `30d`)
    - `JWT_COOKIE_EXPIRE`: JWT cookie expiration time (in days)
+   - `CLIENT_URL`: The base URL of your frontend application (e.g., `http://localhost:3000`), used for OAuth redirects.
+   - `GOOGLE_CLIENT_ID`: Your Google OAuth client ID.
+   - `GOOGLE_CLIENT_SECRET`: Your Google OAuth client secret.
+   - `FACEBOOK_APP_ID`: Your Facebook App ID.
+   - `FACEBOOK_APP_SECRET`: Your Facebook App Secret.
 
 ### Running the Application
 - To start the backend server: `npm run dev` (or `npm start`)

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import AdminApartmentListPage from './pages/admin/ApartmentListPage';
 import AdminReviewListPage from './pages/admin/ReviewListPage';
 import AdminKYCListPage from './pages/admin/KYCListPage';
 import MyApartmentsPage from './pages/MyApartmentsPage';
+import LoginSuccessPage from './pages/LoginSuccessPage';
 import Header from './components/Header';
 import ProtectedRoute from './components/ProtectedRoute';
 import './App.css';
@@ -29,6 +30,7 @@ function App() {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/login-success" element={<LoginSuccessPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/apartments" element={<ApartmentListPage />} />
           <Route path="/apartments/:id" element={<ApartmentDetailsPage />} />

--- a/client/src/components/LoginForm.js
+++ b/client/src/components/LoginForm.js
@@ -51,9 +51,21 @@ const LoginForm = () => {
           required
         />
       </div>
-      <button type="submit" className="btn btn-primary mt-3">
+      <button type="submit" className="btn btn-primary mt-3 w-100">
         {t('login')}
       </button>
+
+      <div className="my-3">
+        <hr />
+        <p className="text-center">OR</p>
+      </div>
+
+      <a className="btn btn-danger w-100 mb-2" href="http://localhost:5000/api/v1/auth/google" role="button">
+        <i className="fab fa-google me-2"></i> Continue with Google
+      </a>
+      <a className="btn btn-primary w-100" href="http://localhost:5000/api/v1/auth/facebook" role="button">
+        <i className="fab fa-facebook me-2"></i> Continue with Facebook
+      </a>
     </form>
   );
 };

--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -50,8 +50,25 @@ export const AuthProvider = ({ children }) => {
     setUser(userData.data);
     };
 
+  const socialLoginCallback = async (token) => {
+    setLoading(true);
+    localStorage.setItem('token', token);
+    try {
+      const { data: userData } = await axios.get('/api/v1/auth/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setUser(userData.data);
+    } catch (error) {
+      console.error('Error loading user after social login', error);
+      localStorage.removeItem('token');
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout, register }}>
+    <AuthContext.Provider value={{ user, loading, login, logout, register, socialLoginCallback }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/LoginSuccessPage.js
+++ b/client/src/pages/LoginSuccessPage.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useContext } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import AuthContext from '../context/AuthContext';
+import Spinner from '../components/Spinner';
+
+const LoginSuccessPage = () => {
+  const { search } = useLocation();
+  const navigate = useNavigate();
+  const { socialLoginCallback, loading } = useContext(AuthContext);
+
+  useEffect(() => {
+    const handleLogin = async () => {
+      const params = new URLSearchParams(search);
+      const token = params.get('token');
+
+      if (token) {
+        await socialLoginCallback(token);
+        // After the context has processed the token and updated the user state, redirect.
+        navigate('/');
+      } else {
+        // If no token is found, something went wrong. Redirect to login page.
+        console.error("No token found in URL after social login attempt.");
+        navigate('/login');
+      }
+    };
+
+    handleLogin();
+  }, [search, navigate, socialLoginCallback]);
+
+  // Display a loading indicator while the token is being processed.
+  return (
+    <div>
+      <h1>Logging you in...</h1>
+      <Spinner />
+    </div>
+  );
+};
+
+export default LoginSuccessPage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.17.1"
+        "mongoose": "^8.17.1",
+        "passport": "^0.7.0",
+        "passport-facebook": "^3.0.0",
+        "passport-google-oauth20": "^2.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -52,6 +55,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcryptjs": {
@@ -791,6 +803,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -842,6 +860,76 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-facebook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-3.0.0.tgz",
+      "integrity": "sha512-K/qNzuFsFISYAyC1Nma4qgY/12V3RSLFdFVsPKXiKZt434wOvthFW1p7zKa1iQihQMRhaWorVE1o3Vi1o+ZgeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -850,6 +938,11 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1140,6 +1233,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1147,6 +1246,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.1"
+    "mongoose": "^8.17.1",
+    "passport": "^0.7.0",
+    "passport-facebook": "^3.0.0",
+    "passport-google-oauth20": "^2.0.0"
   }
 }

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -1,0 +1,99 @@
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const FacebookStrategy = require('passport-facebook').Strategy;
+const mongoose = require('mongoose');
+const User = require('../models/User');
+
+// This function will be exported and called from our main server file
+module.exports = function (passport) {
+  // Google Strategy
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL: '/api/v1/auth/google/callback', // The URI Google will redirect to after user consent
+      },
+      async (accessToken, refreshToken, profile, done) => {
+        // This is the verification callback function that runs after Google auth
+        const newUser = {
+          googleId: profile.id,
+          name: profile.displayName,
+          email: profile.emails[0].value,
+        };
+
+        try {
+          // Check if user already exists in our DB with this Google ID
+          let user = await User.findOne({ googleId: profile.id });
+
+          if (user) {
+            // If user exists, pass them to the next middleware
+            return done(null, user);
+          } else {
+            // If not, check if a user exists with the same email
+            user = await User.findOne({ email: profile.emails[0].value });
+            if (user) {
+              // A user with this email already exists (likely signed up with email/password).
+              // For simplicity, we'll return an error. A more advanced implementation
+              // could link the accounts here.
+              return done(new Error('An account with this email already exists. Please log in with your password to link your account.'), false);
+            }
+            // If no user exists, create a new one
+            user = await User.create(newUser);
+            return done(null, user);
+          }
+        } catch (err) {
+          console.error(err);
+          return done(err, false);
+        }
+      }
+    )
+  );
+
+  // Facebook Strategy (similar logic to Google)
+  passport.use(
+    new FacebookStrategy(
+      {
+        clientID: process.env.FACEBOOK_APP_ID,
+        clientSecret: process.env.FACEBOOK_APP_SECRET,
+        callbackURL: '/api/v1/auth/facebook/callback',
+        profileFields: ['id', 'displayName', 'emails'], // Fields to request from Facebook
+      },
+      async (accessToken, refreshToken, profile, done) => {
+        const newUser = {
+          facebookId: profile.id,
+          name: profile.displayName,
+          email: profile.emails[0].value,
+        };
+
+        try {
+          let user = await User.findOne({ facebookId: profile.id });
+
+          if (user) {
+            return done(null, user);
+          } else {
+            user = await User.findOne({ email: profile.emails[0].value });
+            if (user) {
+                return done(new Error('An account with this email already exists. Please log in with your password to link your account.'), false);
+            }
+            user = await User.create(newUser);
+            return done(null, user);
+          }
+        } catch (err) {
+          console.error(err);
+          return done(err, false);
+        }
+      }
+    )
+  );
+
+  // These functions are needed for session-based authentication, but since we are
+  // using JWTs, Passport sessions are not strictly necessary. However, they are
+  // good practice to include.
+  passport.serializeUser((user, done) => {
+    done(null, user.id);
+  });
+
+  passport.deserializeUser((id, done) => {
+    User.findById(id, (err, user) => done(err, user));
+  });
+};

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -72,9 +72,7 @@ exports.getMe = asyncHandler(async (req, res, next) => {
  */
 const sendTokenResponse = (user, statusCode, res) => {
   // Create token
-  const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
-    expiresIn: process.env.JWT_EXPIRE,
-  });
+  const token = user.getSignedJwtToken();
 
   const options = {
     expires: new Date(
@@ -94,4 +92,26 @@ const sendTokenResponse = (user, statusCode, res) => {
       success: true,
       token,
     });
+};
+
+/**
+ * @desc      Google OAuth callback
+ * @route     GET /api/v1/auth/google/callback
+ * @access    Public
+ */
+exports.googleCallback = (req, res, next) => {
+  const token = req.user.getSignedJwtToken();
+  // Redirect to a frontend route that will handle the token
+  res.redirect(`${process.env.CLIENT_URL}/login-success?token=${token}`);
+};
+
+/**
+ * @desc      Facebook OAuth callback
+ * @route     GET /api/v1/auth/facebook/callback
+ * @access    Public
+ */
+exports.facebookCallback = (req, res, next) => {
+  const token = req.user.getSignedJwtToken();
+  // Redirect to a frontend route that will handle the token
+  res.redirect(`${process.env.CLIENT_URL}/login-success?token=${token}`);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const passport = require('passport');
 const connectDB = require('./config/db');
 
 // Load env vars
@@ -16,6 +17,12 @@ app.use(express.json());
 
 // Enable CORS
 app.use(cors());
+
+// Passport Config
+require('./config/passport')(passport);
+
+// Passport Middleware
+app.use(passport.initialize());
 
 // Mount routers
 const auth = require('./routes/auth');

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 
 const UserSchema = new mongoose.Schema({
   name: {
@@ -21,9 +22,21 @@ const UserSchema = new mongoose.Schema({
   },
   password: {
     type: String,
-    required: [true, 'Please add a password'],
+    required: [
+      function () {
+        // If signing up with a social provider, a password is not required.
+        return !this.googleId && !this.facebookId;
+      },
+      'Password is required for email registration.',
+    ],
     minlength: 6,
     select: false,
+  },
+  googleId: {
+    type: String,
+  },
+  facebookId: {
+    type: String,
   },
   role: {
     type: String,
@@ -54,6 +67,13 @@ UserSchema.pre('save', async function (next) {
 // Match user entered password to hashed password in database
 UserSchema.methods.matchPassword = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
+};
+
+// Sign JWT and return
+UserSchema.methods.getSignedJwtToken = function () {
+  return jwt.sign({ id: this._id }, process.env.JWT_SECRET, {
+    expiresIn: process.env.JWT_EXPIRE,
+  });
 };
 
 module.exports = mongoose.model('User', UserSchema);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,5 +1,12 @@
 const express = require('express');
-const { register, login, getMe } = require('../controllers/authController');
+const passport = require('passport');
+const {
+  register,
+  login,
+  getMe,
+  googleCallback,
+  facebookCallback,
+} = require('../controllers/authController');
 
 const router = express.Router();
 
@@ -8,5 +15,31 @@ const { protect } = require('../middleware/authMiddleware');
 router.post('/register', register);
 router.post('/login', login);
 router.get('/me', protect, getMe);
+
+// --- Social Login Routes ---
+
+// @desc    Authenticate with Google
+// @route   GET /api/v1/auth/google
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+// @desc    Google auth callback
+// @route   GET /api/v1/auth/google/callback
+router.get(
+  '/google/callback',
+  passport.authenticate('google', { session: false, failureRedirect: '/login' }),
+  googleCallback
+);
+
+// @desc    Authenticate with Facebook
+// @route   GET /api/v1/auth/facebook
+router.get('/facebook', passport.authenticate('facebook', { scope: ['email'] }));
+
+// @desc    Facebook auth callback
+// @route   GET /api/v1/auth/facebook/callback
+router.get(
+  '/facebook/callback',
+  passport.authenticate('facebook', { session: false, failureRedirect: '/login' }),
+  facebookCallback
+);
 
 module.exports = router;


### PR DESCRIPTION
This commit introduces social login functionality, allowing users to register and authenticate using their Google or Facebook accounts.

Backend:
- Adds `passport`, `passport-google-oauth20`, and `passport-facebook` dependencies.
- Updates the `User` model to include `googleId` and `facebookId` fields and makes the password optional for social signups.
- Implements Passport.js strategies for Google and Facebook to handle the OAuth 2.0 flow.
- Adds new API endpoints (`/api/v1/auth/google`, `/api/v1/auth/facebook` and their callbacks) to manage the authentication process.
- After a successful social login, the backend generates a JWT and redirects the user back to the frontend with the token.

Frontend:
- Adds "Continue with Google" and "Continue with Facebook" buttons to the `LoginForm` component.
- Creates a new `LoginSuccessPage` to handle the redirect from the backend, extract the JWT from the URL, and save it.
- Updates the `AuthContext` with a new function to process the token from a social login and update the user's authentication state.
- Adds the corresponding route for the success page in `App.js`.

Documentation:
- Creates a `.env.example` file to document all required environment variables.
- Updates `README.md` to include instructions for the new social login environment variables.