### PR TITLE
feat: Add admin page for review moderation

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import AdminApartmentListPage from './pages/admin/ApartmentListPage';
 import AdminReviewListPage from './pages/admin/ReviewListPage';
 import AdminKYCListPage from './pages/admin/KYCListPage';
 import KYCManagementPage from './pages/admin/KYCManagementPage';
+import ReviewModerationPage from './pages/admin/ReviewModerationPage';
 import MyApartmentsPage from './pages/MyApartmentsPage';
 import Header from './components/Header';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -90,6 +91,14 @@ function App() {
             element={
               <AdminRoute>
                 <KYCManagementPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/admin/review-moderation"
+            element={
+              <AdminRoute>
+                <ReviewModerationPage />
               </AdminRoute>
             }
           />

--- a/client/src/pages/AdminDashboardPage.js
+++ b/client/src/pages/AdminDashboardPage.js
@@ -21,6 +21,9 @@ const AdminDashboardPage = () => {
         <li>
           <Link to="/admin/kyc-management">Manage KYC Requests</Link>
         </li>
+        <li>
+          <Link to="/admin/review-moderation">Moderate Reviews</Link>
+        </li>
       </ul>
     </div>
   );

--- a/client/src/pages/admin/ReviewModerationPage.js
+++ b/client/src/pages/admin/ReviewModerationPage.js
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, useContext } from 'react';
+import axios from 'axios';
+import AuthContext from '../../context/AuthContext';
+import Spinner from '../../components/Spinner';
+import Alert from '../../components/Alert';
+
+const ReviewModerationPage = () => {
+  const [pendingReviews, setPendingReviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const { user: adminUser } = useContext(AuthContext);
+
+  const handleUpdateReviewStatus = async (reviewId, status) => {
+    try {
+      const token = localStorage.getItem('token');
+      const config = {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      await axios.put(`/api/v1/reviews/${reviewId}`, { status }, config);
+
+      // Remove the review from the list for instant UI feedback
+      setPendingReviews(pendingReviews.filter(review => review._id !== reviewId));
+    } catch (err) {
+      setError('Failed to update review status.');
+    }
+  };
+
+  useEffect(() => {
+    const fetchReviews = async () => {
+      setLoading(true);
+      try {
+        const token = localStorage.getItem('token');
+        const config = {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        };
+        const { data } = await axios.get('/api/v1/reviews', config);
+
+        // Filter for pending reviews
+        const filteredReviews = data.data.filter(review => review.status === 'Pending');
+
+        setPendingReviews(filteredReviews);
+        setLoading(false);
+      } catch (err) {
+        setError('Error fetching reviews for moderation');
+        setLoading(false);
+      }
+    };
+
+    if (adminUser) {
+      fetchReviews();
+    }
+  }, [adminUser]);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <div>
+      <h1>Review Moderation</h1>
+      {error && <Alert type="danger" message={error} />}
+      {pendingReviews.length === 0 ? (
+        <p>No pending reviews to moderate.</p>
+      ) : (
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th>Apartment</th>
+              <th>Renter</th>
+              <th>Rating</th>
+              <th>Comment</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pendingReviews.map((review) => (
+              <tr key={review._id}>
+                <td>{review.apartment.location}</td>
+                <td>{review.renter.name}</td>
+                <td>{review.rating}</td>
+                <td>{review.comment}</td>
+                <td>
+                  <button
+                    className="btn btn-success btn-sm"
+                    onClick={() => handleUpdateReviewStatus(review._id, 'Approved')}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="btn btn-danger btn-sm ms-2"
+                    onClick={() => handleUpdateReviewStatus(review._id, 'Rejected')}
+                  >
+                    Reject
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default ReviewModerationPage;


### PR DESCRIPTION
This commit adds the final piece of the admin panel functionality: a page for moderating pending reviews.

Key changes:
- Creates a new `ReviewModerationPage.js` component in the admin section of the frontend.
- The page fetches all reviews and filters them to show only those with a "Pending" status.
- Admins can click "Approve" or "Reject" on a review, which calls the `PUT /api/v1/reviews/:id` endpoint to update its status.
- The UI updates in real-time to remove the moderated review from the list.
- Adds a route for the new page and a navigation link from the main admin dashboard.