### PR TITLE
feat: Add admin page for commission management

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,6 +17,7 @@ import AdminReviewListPage from './pages/admin/ReviewListPage';
 import AdminKYCListPage from './pages/admin/KYCListPage';
 import KYCManagementPage from './pages/admin/KYCManagementPage';
 import ReviewModerationPage from './pages/admin/ReviewModerationPage';
+import CommissionPage from './pages/admin/CommissionPage';
 import MyApartmentsPage from './pages/MyApartmentsPage';
 import Header from './components/Header';
 import ProtectedRoute from './components/ProtectedRoute';
@@ -99,6 +100,14 @@ function App() {
             element={
               <AdminRoute>
                 <ReviewModerationPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="/admin/commission"
+            element={
+              <AdminRoute>
+                <CommissionPage />
               </AdminRoute>
             }
           />

--- a/client/src/pages/AdminDashboardPage.js
+++ b/client/src/pages/AdminDashboardPage.js
@@ -24,6 +24,9 @@ const AdminDashboardPage = () => {
         <li>
           <Link to="/admin/review-moderation">Moderate Reviews</Link>
         </li>
+        <li>
+          <Link to="/admin/commission">Manage Commission</Link>
+        </li>
       </ul>
     </div>
   );

--- a/client/src/pages/admin/CommissionPage.js
+++ b/client/src/pages/admin/CommissionPage.js
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import Spinner from '../../components/Spinner';
+import Alert from '../../components/Alert';
+
+const CommissionPage = () => {
+  const [commission, setCommission] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    const fetchCommission = async () => {
+      try {
+        const { data } = await axios.get('/api/v1/settings/commission_fee');
+        setCommission(data.data.value);
+        setLoading(false);
+      } catch (err) {
+        setError('Error fetching commission fee.');
+        setLoading(false);
+      }
+    };
+
+    fetchCommission();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    try {
+      const token = localStorage.getItem('token');
+      const config = {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      await axios.put('/api/v1/settings/commission_fee', { value: commission }, config);
+      setSuccess('Commission fee updated successfully!');
+    } catch (err) {
+      setError('Failed to update commission fee.');
+    }
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  return (
+    <div>
+      <h1>Commission Fee Management</h1>
+      <p>Set the commission fee percentage for all transactions on the platform.</p>
+
+      {error && <Alert type="danger" message={error} />}
+      {success && <Alert type="success" message={success} />}
+
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="commission">Commission Fee (%)</label>
+          <input
+            type="number"
+            id="commission"
+            className="form-control"
+            value={commission}
+            onChange={(e) => setCommission(e.target.value)}
+            placeholder="e.g., 10"
+            required
+            min="0"
+            max="100"
+          />
+        </div>
+        <button type="submit" className="btn btn-primary mt-3">
+          Save Commission Fee
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default CommissionPage;

--- a/src/controllers/settingController.js
+++ b/src/controllers/settingController.js
@@ -1,0 +1,38 @@
+const Setting = require('../models/Setting');
+const ErrorResponse = require('../utils/errorResponse');
+const asyncHandler = require('../middleware/async');
+
+// @desc    Get a single setting by key
+// @route   GET /api/v1/settings/:key
+// @access  Public
+exports.getSetting = asyncHandler(async (req, res, next) => {
+  const setting = await Setting.findOne({ key: req.params.key });
+
+  if (!setting) {
+    // If the setting doesn't exist, we can return a default or an error.
+    // For commission_fee, we'll return a default if it's not set.
+    if (req.params.key === 'commission_fee') {
+      return res.status(200).json({ success: true, data: { key: 'commission_fee', value: '10' } }); // Default to 10%
+    }
+    return next(new ErrorResponse(`Setting with key '${req.params.key}' not found`, 404));
+  }
+
+  res.status(200).json({ success: true, data: setting });
+});
+
+// @desc    Update a setting
+// @route   PUT /api/v1/settings/:key
+// @access  Private (Admin)
+exports.updateSetting = asyncHandler(async (req, res, next) => {
+  const { key } = req.params;
+  const { value } = req.body;
+
+  // Use findOneAndUpdate with upsert to create the setting if it doesn't exist
+  const setting = await Setting.findOneAndUpdate(
+    { key },
+    { value },
+    { new: true, upsert: true, runValidators: true }
+  );
+
+  res.status(200).json({ success: true, data: setting });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ const bookings = require('./routes/bookings');
 const reviews = require('./routes/reviews');
 const users = require('./routes/users');
 const payments = require('./routes/payments');
+const settings = require('./routes/settings');
 
 app.use('/api/v1/auth', auth);
 app.use('/api/v1/apartments', apartments);
@@ -52,6 +53,7 @@ app.use('/api/v1/bookings', bookings);
 app.use('/api/v1/reviews', reviews);
 app.use('/api/v1/users', users);
 app.use('/api/v1/payments', payments);
+app.use('/api/v1/settings', settings);
 
 const errorHandler = require('./middleware/error');
 app.use(errorHandler);

--- a/src/models/Setting.js
+++ b/src/models/Setting.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+const SettingSchema = new mongoose.Schema({
+  key: {
+    type: String,
+    required: true,
+    unique: true,
+    enum: ['commission_fee'], // Enum to control which settings are allowed
+  },
+  value: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  updatedAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+SettingSchema.pre('save', function (next) {
+  this.updatedAt = Date.now();
+  next();
+});
+
+module.exports = mongoose.model('Setting', SettingSchema);

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const {
+  getSetting,
+  updateSetting,
+} = require('../controllers/settingController');
+
+const router = express.Router();
+
+const { protect, authorize } = require('../middleware/authMiddleware');
+
+// Route to get a specific setting
+router.route('/:key').get(getSetting);
+
+// Route to update a specific setting (admin only)
+router.route('/:key').put(protect, authorize('admin'), updateSetting);
+
+module.exports = router;


### PR DESCRIPTION
This commit adds the final planned admin feature: a page for managing the platform's commission fee.

Key changes:
- Adds a new `Setting` model to the backend to store key-value settings like the commission fee.
- Creates new API endpoints (`/api/v1/settings`) for getting and updating settings.
- Creates a new `CommissionPage.js` component in the admin section of the frontend.
- The page fetches and displays the current commission fee and provides a form for the admin to update it.
- Adds a route for the new page and a navigation link from the main admin dashboard.